### PR TITLE
migrate RBAC to auth delegator

### DIFF
--- a/rhoai-uwm-grafana/base/instance/grafana-proxy-rbac.yaml
+++ b/rhoai-uwm-grafana/base/instance/grafana-proxy-rbac.yaml
@@ -1,30 +1,12 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: ClusterRoleBinding
 metadata:
-  name: grafana-proxy
-rules:
-  - verbs:
-      - create
-    apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-  - verbs:
-      - create
-    apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: grafana-proxy
+  name: auth-delegator-user-grafana
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: grafana-proxy
+  name: system:auth-delegator
 subjects:
-  - kind: ServiceAccount
-    name: grafana-sa
+- kind: ServiceAccount
+  name: grafana-sa
+  namespace: user-grafana


### PR DESCRIPTION
When testing on 4.19, the Grafana instance throws errors in the logs related to `create ``subjectaccessreviews` and `tokenreviews` despite the existing custom role granting those permissions.  

There may be other required permissions that are needed in addition to `create`.

Instead of updating the custom role, there is a default role designed to be used with an oauth proxy already that contains these permissions called `system:auth-delegator`.

Granting this permission resolves the error messages in the logs.